### PR TITLE
Implement user repository and integrate with service

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -5,11 +5,20 @@ import (
 	"net/http"
 
 	"github.com/example/user-service/api/router"
+	"github.com/example/user-service/client"
+	"github.com/example/user-service/config"
+	"github.com/example/user-service/repository"
 	"github.com/example/user-service/service"
 )
 
 func main() {
-	svc := service.NewUserService()
+	cfg := config.Load()
+	db, err := client.DB(cfg)
+	if err != nil {
+		log.Fatal(err)
+	}
+	repo := repository.NewPgUserRepository(db)
+	svc := service.NewUserService(repo)
 	r := router.New(svc)
 
 	log.Println("Starting HTTP server on :8080")

--- a/repository/pg_user_repository.go
+++ b/repository/pg_user_repository.go
@@ -1,4 +1,53 @@
 package repository
 
+import (
+	"context"
+	"database/sql"
+
+	"github.com/example/user-service/model"
+)
+
 // PgUserRepository implements UserRepository backed by Postgres.
-type PgUserRepository struct{}
+type PgUserRepository struct {
+	db *sql.DB
+}
+
+// NewPgUserRepository creates a new PgUserRepository.
+func NewPgUserRepository(db *sql.DB) *PgUserRepository {
+	return &PgUserRepository{db: db}
+}
+
+// Create inserts a new user into the database.
+func (r *PgUserRepository) Create(ctx context.Context, u model.User) error {
+	_, err := r.db.ExecContext(ctx, `INSERT INTO users (id, name) VALUES ($1, $2)`, u.ID, u.Name)
+	return err
+}
+
+// List returns all users from the database.
+func (r *PgUserRepository) List(ctx context.Context) ([]model.User, error) {
+	rows, err := r.db.QueryContext(ctx, `SELECT id, name FROM users`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var users []model.User
+	for rows.Next() {
+		var u model.User
+		if err := rows.Scan(&u.ID, &u.Name); err != nil {
+			return nil, err
+		}
+		users = append(users, u)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return users, nil
+}
+
+// ByID returns a user by id.
+func (r *PgUserRepository) ByID(ctx context.Context, id string) (model.User, error) {
+	var u model.User
+	err := r.db.QueryRowContext(ctx, `SELECT id, name FROM users WHERE id = $1`, id).Scan(&u.ID, &u.Name)
+	return u, err
+}

--- a/repository/user_repository.go
+++ b/repository/user_repository.go
@@ -1,5 +1,17 @@
 package repository
 
+import (
+	"context"
+
+	"github.com/example/user-service/model"
+)
+
+// UserRepository defines persistence operations for users.
 type UserRepository interface {
-	// TODO: define repository methods
+	// Create persists a new user.
+	Create(ctx context.Context, u model.User) error
+	// List returns all users.
+	List(ctx context.Context) ([]model.User, error)
+	// ByID finds a user by identifier.
+	ByID(ctx context.Context, id string) (model.User, error)
 }

--- a/service/user_service.go
+++ b/service/user_service.go
@@ -1,19 +1,22 @@
 package service
 
-import "github.com/example/user-service/model"
+import (
+	"context"
+
+	"github.com/example/user-service/model"
+	"github.com/example/user-service/repository"
+)
 
 // UserService contains core business logic.
 type UserService struct {
-	users []model.User
+	repo  repository.UserRepository
 	chars map[string][]model.Character
 }
 
-func NewUserService() *UserService {
+// NewUserService constructs a UserService with the provided repository.
+func NewUserService(repo repository.UserRepository) *UserService {
 	return &UserService{
-		users: []model.User{
-			{ID: "1", Name: "Alice"},
-			{ID: "2", Name: "Bob"},
-		},
+		repo: repo,
 		chars: map[string][]model.Character{
 			"1": {
 				{ID: "c1", UserID: "1", Name: "Warrior"},
@@ -28,7 +31,11 @@ func NewUserService() *UserService {
 
 // ListUsers returns all users.
 func (s *UserService) ListUsers() []model.User {
-	return s.users
+	users, err := s.repo.List(context.Background())
+	if err != nil {
+		return nil
+	}
+	return users
 }
 
 // ListCharacters returns all characters for a given user.


### PR DESCRIPTION
## Summary
- create `UserRepository` interface
- implement a Postgres-backed `PgUserRepository`
- refactor `UserService` to use repository instead of hardcoded users
- wire repository into HTTP server startup

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_687406a9b2b08321896602436f912f4d