### PR TITLE
Add run instructions and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: deps api worker subscriber
+
+deps:
+	go mod download
+
+api:
+	go run ./cmd/api
+
+worker:
+	go run ./cmd/worker
+
+subscriber:
+	go run ./cmd/subscriber

--- a/README.md
+++ b/README.md
@@ -43,3 +43,26 @@ GitHub Actions will execute the same checks on every push or pull request via `.
 - `GET /ping` - health check
 - `GET /users` - list all users
 - `GET /users/{id}/characters` - list characters for a user
+## Installation
+
+Ensure Go 1.24 or newer is installed. Download dependencies with:
+
+```bash
+make deps
+```
+
+## Environment Variables
+
+- `NATS_URL` - NATS server URL
+- `TEMPORAL_URL` - Temporal frontend address
+- `DATABASE_URL` - PostgreSQL connection string
+
+## Running the Services
+
+Each component can be started individually:
+
+```bash
+make api        # launches the REST API on :8080
+make worker     # runs the Temporal worker
+make subscriber # starts the NATS subscriber
+```


### PR DESCRIPTION
## Summary
- update README with installation instructions, environment variables and commands to run API, worker, and subscriber
- add Makefile to simplify local execution

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_687408002a3483218a8ba1bba17a6f21