### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+# Exclude git directory
+.git
+# Exclude test files
+*.test
+*.out
+coverage.*
+*.coverprofile
+profile.cov
+# Exclude editor configs
+.idea
+.vscode
+# Exclude environment files
+.env
+# Exclude vendor if used
+vendor/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# syntax=docker/dockerfile:1
+
+FROM golang:1.21 AS builder
+WORKDIR /app
+
+# Cache dependencies
+COPY go.mod ./
+RUN go mod download
+
+# Copy source
+COPY . .
+
+# Build binaries
+RUN CGO_ENABLED=0 go build -o /bin/api ./cmd/api
+RUN CGO_ENABLED=0 go build -o /bin/worker ./cmd/worker
+RUN CGO_ENABLED=0 go build -o /bin/subscriber ./cmd/subscriber
+
+FROM debian:bullseye-slim
+WORKDIR /app
+
+# Copy binaries and entrypoint
+COPY --from=builder /bin/api /usr/local/bin/api
+COPY --from=builder /bin/worker /usr/local/bin/worker
+COPY --from=builder /bin/subscriber /usr/local/bin/subscriber
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+EXPOSE 8080
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["api"]

--- a/README.md
+++ b/README.md
@@ -66,3 +66,18 @@ make api        # launches the REST API on :8080
 make worker     # runs the Temporal worker
 make subscriber # starts the NATS subscriber
 ```
+
+## Docker
+
+Build the Docker image and run the API service (default):
+
+```bash
+docker build -t user-service .
+docker run --rm -p 8080:8080 user-service
+```
+
+To run the worker or subscriber instead, set the `SERVICE` environment variable:
+
+```bash
+docker run --rm -e SERVICE=worker user-service
+```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+
+# Default service is api
+SERVICE=${SERVICE:-api}
+exec "/usr/local/bin/$SERVICE"


### PR DESCRIPTION
## Summary
- provide Dockerfile and entrypoint script
- ignore build/test artifacts with `.dockerignore`
- document Docker usage in README

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_68740a0277988321bb7b5417ddb0125e