### PR TITLE
Update to Go 1.24 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.21 AS builder
+FROM golang:1.24 AS builder
 WORKDIR /app
 
 # Cache dependencies


### PR DESCRIPTION
## Summary
- update Dockerfile to use Go 1.24

## Testing
- `go mod download`
- `docker build .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68740f18b5808321b05b2e8fbaa235ba