### PR TITLE
Update workflow to Go 1.24

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -13,6 +13,6 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 'stable'
+          go-version: '1.24.x'
       - name: Run checks
         run: ./scripts/check.sh


### PR DESCRIPTION
## Summary
- update GitHub actions to use Go 1.24

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_68740f8f9730832185908638ae470f6d