### PR TITLE
Add gitattributes for shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
## Summary
- ensure shell scripts always use Unix line endings by adding `.gitattributes`

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_687411d55cbc832182fb94a41d1cd739